### PR TITLE
Allow corpus name to be accessed as a category

### DIFF
--- a/chatterbot_corpus/corpus.py
+++ b/chatterbot_corpus/corpus.py
@@ -1,6 +1,17 @@
 import os
 
 
+class CorpusObject(list):
+
+    def __init__(self, *args, **kwargs):
+        if args:
+            super(CorpusObject, self).__init__(args[0])
+        else:
+            super(CorpusObject, self).__init__()
+
+        self.categories = []
+
+
 class Corpus(object):
 
     def __init__(self):
@@ -69,12 +80,13 @@ class Corpus(object):
         """
         data_file_paths = self.list_corpus_files(dotted_path)
 
-        corpora = []
+        corpora = CorpusObject()
 
         for file_path in data_file_paths:
             corpus = self.read_corpus(file_path)
 
             for key in list(corpus.keys()):
                 corpora.append(corpus[key])
+                corpora.categories.append(key)
 
         return corpora

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -34,11 +34,17 @@ class CorpusUtilsTestCase(TestCase):
 
         self.assertIn('.yml', data_files[0])
 
-    def test_load_corpus(self):
+    def test_load_english_corpus(self):
         corpus = self.corpus.load_corpus('chatterbot.corpus.english.greetings')
 
         self.assertEqual(len(corpus), 1)
         self.assertIn(['Hi', 'Hello'], corpus[0])
+
+    def test_load_english_corpus_categories(self):
+        corpus = self.corpus.load_corpus('chatterbot.corpus.english.greetings')
+
+        self.assertEqual(len(corpus), 1)
+        self.assertIn('greetings', corpus.categories)
 
 
 class CorpusLoadingTestCase(TestCase):


### PR DESCRIPTION
Categorization is a useful feature that is required for a number of text-clarification algorithms. This pull request makes changes so that the name of each corpus can be returned as a category that describes the collection of text.