### PR TITLE
Fix where category is stored

### DIFF
--- a/chatterbot_corpus/corpus.py
+++ b/chatterbot_corpus/corpus.py
@@ -12,6 +12,9 @@ class CorpusObject(list):
     """
 
     def __init__(self, *args, **kwargs):
+        """
+        Imitate a list by allowing a value to be passed in.
+        """
         if args:
             super(CorpusObject, self).__init__(args[0])
         else:
@@ -88,14 +91,16 @@ class Corpus(object):
         """
         data_file_paths = self.list_corpus_files(dotted_path)
 
-        corpora = CorpusObject()
+        corpora = []
 
         for file_path in data_file_paths:
-            corpus = self.read_corpus(file_path)
+            corpus = CorpusObject()
+            corpus_data = self.read_corpus(file_path)
 
-            corpora.categories = corpus.get('categories', [])
-            conversations = corpus.get('conversations', [])
+            conversations = corpus_data.get('conversations', [])
+            corpus.categories = corpus_data.get('categories', [])
+            corpus.extend(conversations)
 
-            corpora.extend([conversations])
+            corpora.append(corpus)
 
         return corpora

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -45,7 +45,10 @@ class CorpusUtilsTestCase(TestCase):
         corpus = self.corpus.load_corpus('chatterbot.corpus.english.greetings')
 
         self.assertEqual(len(corpus), 1)
-        self.assertIn('greetings', corpus.categories)
+
+        # Test that each conversation gets labeled with the correct category
+        for conversation in corpus:
+            self.assertIn('greetings', conversation.categories)
 
 
 class CorpusLoadingTestCase(TestCase):


### PR DESCRIPTION
This makes a change so that the categories for a corpus will be stored on each list of conversations that get returned for the selected data file. Previously the categories were being aggregated into a single list for all of the selected corpses that were loaded into the result list.

This is intended to be an alternative approach to #38. The main difference is that this pull request changes where the categories are stored instead of altering the structure of the category list.